### PR TITLE
fix: not working with psr/simple-cache v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
   ],
   "require": {
     "ext-json": "*",
-    "php": "^7.0|^8.0",
-    "phpoffice/phpspreadsheet": "^1.18",
+    "php": "^8.0",
+    "phpoffice/phpspreadsheet": "^1.25",
     "illuminate/support": "5.8.*|^6.0|^7.0|^8.0|^9.0",
-    "psr/simple-cache": "^1.0|^2.0"
+    "psr/simple-cache": "^3.0"
   },
   "require-dev": {
     "orchestra/testbench": "^6.0|^7.0",

--- a/src/Cache/MemoryCache.php
+++ b/src/Cache/MemoryCache.php
@@ -27,7 +27,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function clear()
+    public function clear(): bool
     {
         $this->cache = [];
 
@@ -37,7 +37,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function delete($key)
+    public function delete(string $key): bool
     {
         unset($this->cache[$key]);
 
@@ -47,7 +47,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function deleteMultiple($keys)
+    public function deleteMultiple(iterable $keys): bool
     {
         foreach ($keys as $key) {
             $this->delete($key);
@@ -59,7 +59,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function get($key, $default = null)
+    public function get(string $key, mixed $default = null): mixed
     {
         if ($this->has($key)) {
             return $this->cache[$key];
@@ -71,7 +71,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function getMultiple($keys, $default = null)
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
         $results = [];
         foreach ($keys as $key) {
@@ -84,7 +84,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function has($key)
+    public function has(string $key): bool
     {
         return isset($this->cache[$key]);
     }
@@ -92,7 +92,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function set($key, $value, $ttl = null)
+    public function set(string $key, mixed $value, \DateInterval|int|null $ttl = null): bool
     {
         $this->cache[$key] = $value;
 
@@ -102,7 +102,7 @@ class MemoryCache implements CacheInterface
     /**
      * {@inheritdoc}
      */
-    public function setMultiple($values, $ttl = null)
+    public function setMultiple(iterable $values, \DateInterval|int|null $ttl = null): bool
     {
         foreach ($values as $key => $value) {
             $this->set($key, $value);


### PR DESCRIPTION
Please take note of our contributing guidelines: https://docs.laravel-excel.com/3.1/getting-started/contributing.html
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

1️⃣  Why should it be added? What are the benefits of this change?
Fixes Laravel Excel not working with Laravel 9 because Laravel 9 installs psr/simple-cache v3 and Laravel Excel is not compatible with v3.

This PR is the same as PR `3733` which was closed because:

> Sorry this is not an option, this will introduce too many breaking changes for now

Another issue mentions:

> This package doesn't require outdated versions, however PhpSpreadsheet doesn't support the newest version of the simple-cache interfaces yet (Laravel supports v1, 2 and 3, but composer will always install the latest first if no other dependency needs a lower one).

I believe PhpSpreadsheet also needed updating (`3057`) to `v1.25.0` which has now happened, and so this PR also raises the minimum version for that dependency.

Fixes issues:

- `3805`
- `3787`
- `3758`
- `3755`
- `3743`
- `3738`
- `3731`
- `3718`
- `3668`
- `3611`
- `3576`
- `3535`

2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No.

3️⃣  Does it include tests, if possible?
No.

4️⃣  Any drawbacks? Possible breaking changes?
Will no longer support PHP 7.4 (PHP 7.4 is no longer supported)

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [x] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- - it was closed
- [ ] Added tests to ensure against regression.
- - it's a fix
- [ ] Updated the changelog

6️⃣  Thanks for contributing! 🙌
